### PR TITLE
Fixing error "TypeError: Logger.Log is not a function" by lowercasing the function name

### DIFF
--- a/checker.js
+++ b/checker.js
@@ -70,7 +70,7 @@ function addFileOrFolder(parentPath, file, type, inheritShare) {
             resultFiles.push(fileData);
         }
     } catch (err) {
-        Logger.Log('Error while analyzing file %s : %s', filePath, err)
+        Logger.log('Error while analyzing file %s : %s', filePath, err)
         const fileData = [
             err,
             filePath,


### PR DESCRIPTION
Fixing error "TypeError: Logger.Log is not a function" by lowercasing the function name

See also:

https://github.com/moya-a/G-Drive-SharedFiles-Checker/commit/ef06dd80dd7a8f6a99f4b0346d669053cd64f677#r53897260